### PR TITLE
updating Pipfile to require 3.5.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 *.pyc
 config.py
+.pytest_cache
+.python-version

--- a/Pipfile
+++ b/Pipfile
@@ -11,4 +11,4 @@ pick = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.6"
+python_version = "3.5.3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f1e33c06830b08b684e2fb53559180d1ccb209788720848aa5386bf233f89b99"
+            "sha256": "ae3538f4cbde356c46f0e7ee33e905bf23f00f7bc6ce5663dbcba050bae19b24"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.5.3"
         },
         "sources": [
             {


### PR DESCRIPTION
changed required version in Pipfile
made sure everything runs in 3.5.3 (so far as I could tell)
added a couple things to .gitignore (just a few local artifacts that resulted from having to manage multiple python versions on a mac)