### PR TITLE
Persist book object

### DIFF
--- a/trader/exchange/book.py
+++ b/trader/exchange/book.py
@@ -1,22 +1,37 @@
 import logging
 import logging.config
 
+from sqlalchemy import Column, String
+from sqlalchemy.orm import relationship
+
 from . import trading
 from .order import Order
 import config
-
-from ..database.manager import BaseWrapper, Engine, Test_Engine
-
+from ..database.manager import (
+  BaseWrapper, Engine, Test_Engine, test_session, session
+)
 logging.config.dictConfig(config.log_config)
 logger = logging.getLogger(__name__)
+JOIN_STRING = "and_(Book.id==Order.book_id, Order._status=={})"
 
 
-class Book():
+class Book(BaseWrapper):
+
+  pair = Column("pair", String(15))
+  orders = relationship(Order, lazy="dynamic", collection_class=set)
+
+  # dynamic_loader()
+  # collection_class=attribute_mapped_collection('exchange_id')
+  # ready_orders = orders.filter(Order.status == "ready")
+  # open_orders = orders.filter(Order.status == "open")
+  # filled_orders = orders.filter(Order.status == "filled")
+  # rejected_orders = orders.filter(Order.status == "rejected")
+  # cancel_orders = orders.filter(Order.status == "canceled")
 
   def __init__(self, pair, persist=True, test=True):
 
     self.pair = pair
-    self.unsent_orders = []
+    self.ready_orders = []
     self.open_orders = []
     self.filled_orders = []
     self.canceled_orders = []
@@ -24,35 +39,33 @@ class Book():
     self.test = test
     logger.debug("Book.test: {}".format(self.test))
 
-    # Temporary home for table creation
-    if test:
-      BaseWrapper.metadata.create_all(Test_Engine)
-    else:
-      BaseWrapper.metadata.create_all(Engine)
-
   def add_order(self, side, size, price, post_only=True):
     order = Order(
       self.pair, side, size, price, post_only=post_only,
       persist=self.persist, test=self.test
     )
-    order.save()
-    self.unsent_orders.append(order)
+    self.ready_orders.append(order)
+    if self.persist:
+      order.save()
 
   def send_orders(self):
-    for order in self.unsent_orders:
+    while len(self.ready_orders) > 0:
+      order = self.ready_orders.pop()
       trading.send_order(order)
+      order.status = "pending"
       trading.confirm_order(order)
+      order.status = "open"
       self.open_orders.append(order)
-    self.unsent_orders = []
 
   def cancel_all_orders(self):
     self.cancel_order_list(self.open_orders)
 
   def cancel_order_list(self, order_list):
-    for order in order_list:
+    while len(self.open_orders) > 0:
+      order = self.open_orders.pop()
       trading.cancel_order(order)
+      order.status = "canceled"
       self.canceled_orders.append(order)
-    self.open_orders = [o for o in self.open_orders if o not in order_list]
 
   def order_filled(self, order_id):
     filled_order = next(

--- a/trader/exchange/order.py
+++ b/trader/exchange/order.py
@@ -3,7 +3,9 @@ import logging
 import logging.config
 from decimal import Decimal
 
-from sqlalchemy import Column, String, Numeric, Boolean
+from sqlalchemy import (
+  Column, String, Numeric, Boolean, ForeignKey
+)
 
 from ..database.manager import (
   BaseWrapper, Engine, Test_Engine, test_session, session
@@ -19,6 +21,7 @@ class Order(BaseWrapper):
 
   # Setting up database table
   _exchange_id = Column("exchange_id", String(40))
+  book_id = Column("book_id", ForeignKey("books.id"))
   _pair = Column("pair", String(15))
   _side = Column("side", String(4))
   _price = Column("price", Numeric(precision=13, scale=5))
@@ -38,8 +41,6 @@ class Order(BaseWrapper):
     else:
       self.session = session
       self.engine = Engine
-
-    print("Order t" + str(self.session))
 
     self.pair = pair
     self.side = side

--- a/trader/exchange/test/integration/test_book.py
+++ b/trader/exchange/test/integration/test_book.py
@@ -8,6 +8,7 @@ from ....database.manager import (
 class Test_Order_Integration(unittest.TestCase):
 
   def setUp(self):
+    BaseWrapper.metadata.create_all(Test_Engine)
     self.book = Book("BTC-USD", test=True, persist=False)
 
   def tearDown(self):

--- a/trader/exchange/test/integration/test_book.py
+++ b/trader/exchange/test/integration/test_book.py
@@ -8,7 +8,7 @@ from ....database.manager import (
 class Test_Order_Integration(unittest.TestCase):
 
   def setUp(self):
-    self.book = Book("BTC-USD", test=True)
+    self.book = Book("BTC-USD", test=True, persist=False)
 
   def tearDown(self):
     self.book.cancel_all_orders()
@@ -17,7 +17,7 @@ class Test_Order_Integration(unittest.TestCase):
 
   def test_init(self):
     self.book.add_order("buy", 1, 1)
-    order = self.book.unsent_orders[0]
+    order = self.book.ready_orders[0]
     order.save()
     order.session.commit()
 

--- a/trader/exchange/test/integration/test_order.py
+++ b/trader/exchange/test/integration/test_order.py
@@ -17,8 +17,9 @@ logger = logging.getLogger(__name__)
 class Test_Order_Integration(unittest.TestCase):
 
   def setUp(self):
+    mm = trading.get_mid_market_price("BTC-USD", test=True)
     BaseWrapper.metadata.create_all(Test_Engine)
-    self.test_order = Order("BTC-USD", "buy", 1, 1, test=True)
+    self.test_order = Order("BTC-USD", "buy", 1, mm / 2, test=True)
 
   def tearDown(self):
     test_session.close()
@@ -51,18 +52,20 @@ class Test_Order_Integration(unittest.TestCase):
       self.test_order.id, test=True
     )
     self.assertEqual(order_in_db[1], self.test_order.created_at)
-
+    # TODO: Issue 35 change or create get_order_from_db to return a dictionary
     # Exchange does not exist until sent
     self.assertIsNone(order_in_db[2])
+    self.assertIsNone(order_in_db[3])
     self.assertIsNone(self.test_order.exchange_id)
-    self.assertEqual(order_in_db[3], self.test_order.pair)
-    self.assertEqual(order_in_db[4], self.test_order.side)
-    self.assertEqual(order_in_db[5], self.test_order.size)
+    self.assertIsNone(self.test_order.book_id)
+    self.assertEqual(order_in_db[4], self.test_order.pair)
+    self.assertEqual(order_in_db[5], self.test_order.side)
     self.assertEqual(order_in_db[6], self.test_order.price)
-    self.assertEqual(order_in_db[7], self.test_order.filled)
-    self.assertEqual(order_in_db[8], self.test_order.status)
-    self.assertEqual(order_in_db[9], self.test_order.post_only)
-    self.assertEqual(order_in_db[10], self.test_order.test)
+    self.assertEqual(order_in_db[7], self.test_order.size)
+    self.assertEqual(order_in_db[8], self.test_order.filled)
+    self.assertEqual(order_in_db[9], self.test_order.status)
+    self.assertEqual(order_in_db[10], self.test_order.post_only)
+    self.assertEqual(order_in_db[11], self.test_order.test)
 
   def test_send(self):
 
@@ -80,10 +83,10 @@ class Test_Order_Integration(unittest.TestCase):
 
     self.assertIsNone(pre_sent_db[2])
     self.assertIsNotNone(sent_db[2])
-    self.assertEqual(sent_db[8], "pending")
+    self.assertEqual(sent_db[9], "pending")
     self.assertEqual(self.test_order.status, "pending")
 
-    for i in (0, 1, 3, 4, 5, 6, 7, 9, 10):
+    for i in (0, 1, 3, 4, 5, 6, 7, 10, 11):
       logger.debug("Testing column {}.".format(i))
       self.assertEqual(pre_sent_db[i], sent_db[i])
 
@@ -96,8 +99,7 @@ class Test_Order_Integration(unittest.TestCase):
     order_in_db = get_order_from_db(
       self.test_order.id, test=True
     )
-
-    self.assertEqual(order_in_db[8], "canceled")
+    self.assertEqual(order_in_db[9], "canceled")
     self.assertEqual(self.test_order.status, "canceled")
 
   def test_delete(self):

--- a/trader/exchange/test/unit/test_book.py
+++ b/trader/exchange/test/unit/test_book.py
@@ -13,7 +13,7 @@ class Test_Book(unittest.TestCase):
   def test_book_init(self):
 
     self.assertEqual(self.book.pair, "BTC-USD")
-    self.assertEqual(self.book.unsent_orders, [])
+    self.assertEqual(self.book.ready_orders, [])
     self.assertEqual(self.book.open_orders, [])
     self.assertEqual(self.book.filled_orders, [])
     self.assertEqual(self.book.canceled_orders, [])
@@ -22,9 +22,9 @@ class Test_Book(unittest.TestCase):
     price = round(-1 + self.market_price, 2)
     self.book.add_order("buy", ".1", price)
 
-    self.assertEqual(len(self.book.unsent_orders), 1)
+    self.assertEqual(len(self.book.ready_orders), 1)
 
-    order = self.book.unsent_orders[0]
+    order = self.book.ready_orders[0]
     self.assertEqual(order.price, price)
     self.assertEqual(order.pair, "BTC-USD")
     self.assertEqual(order.size, Decimal(".1"))
@@ -33,8 +33,8 @@ class Test_Book(unittest.TestCase):
     price = round(-1 + self.market_price, 2)
     self.book.add_order("sell", ".11", price)
 
-    self.assertEqual(len(self.book.unsent_orders), 2)
-    order = self.book.unsent_orders[1]
+    self.assertEqual(len(self.book.ready_orders), 2)
+    order = self.book.ready_orders[1]
     self.assertEqual(order.price, price)
     self.assertEqual(order.pair, "BTC-USD")
     self.assertEqual(order.size, Decimal(".11"))
@@ -45,7 +45,7 @@ class Test_Book(unittest.TestCase):
     self.book.add_order("sell", ".11", price)
     self.book.send_orders()
 
-    self.assertEqual(self.book.unsent_orders, [])
+    self.assertEqual(self.book.ready_orders, [])
     self.assertEqual(len(self.book.open_orders), 1)
 
     send_id = self.book.open_orders[0].exchange_id
@@ -57,7 +57,7 @@ class Test_Book(unittest.TestCase):
     self.book.add_order("sell", ".2", self.market_price + 2)
     self.book.send_orders()
 
-    self.assertEqual(self.book.unsent_orders, [])
+    self.assertEqual(self.book.ready_orders, [])
     self.assertEqual(len(self.book.open_orders), 3)
 
     book_ids = {order.exchange_id for order in self.book.open_orders}
@@ -67,7 +67,6 @@ class Test_Book(unittest.TestCase):
     self.assertEqual(book_ids, sent_ids)
 
     self.book.cancel_all_orders()
-
     self.assertEqual(self.book.open_orders, [])
     self.assertEqual(len(self.book.canceled_orders), 3)
 

--- a/trader/exchange/trading.py
+++ b/trader/exchange/trading.py
@@ -121,11 +121,19 @@ def get_book(pair, level, test=False):
 
 
 def get_mid_market_price(pair, test=False):
+  ask, bid = get_first_book(pair, test)
+  return (Decimal(ask[0][0]) + Decimal(bid[0][0])) / 2
+
+
+def get_first_book(pair, test=False):
+  '''
+  book = {'asks': [['19000.01', '50000.07', 196]],
+ 'bids': [['19000', '0.003', 3]],
+ 'sequence': 45787580}
+  '''
   book = get_book(pair, 1, test=test)
   logger.debug(pformat(book))
-  ask = Decimal(book["asks"][0][0])
-  bid = Decimal(book["bids"][0][0])
-  return (ask + bid) / 2
+  return book["asks"], book["bids"]
 
 
 def get_open_orders(pair=None, test=True):

--- a/trader/sequence/book_manager.py
+++ b/trader/sequence/book_manager.py
@@ -5,6 +5,8 @@ import logging.config
 from ..exchange.book import Book
 import config
 from ..database.manager import session, test_session
+from trader.database.manager import (
+  BaseWrapper, Engine, Test_Engine)
 
 logging.config.dictConfig(config.log_config)
 logger = logging.getLogger(__name__)
@@ -17,6 +19,13 @@ class BookManager():
     self.test = terms.test
     self.persist = persist
     logger.debug("BookManager.test: {}".format(self.test))
+
+    # Temporary home for table creation
+    if terms.test:
+      BaseWrapper.metadata.create_all(Test_Engine)
+    else:
+      BaseWrapper.metadata.create_all(Engine)
+
     self.book = Book(terms.pair, persist=persist, test=self.test)
 
     first_buy_price = terms.mid_price - terms.price_change
@@ -138,11 +147,11 @@ class BookManager():
   def add_and_send_orders(self, side, count, first_size, first_price,
                           size_change):
     logger.info("*SENDING ORDERS FOR ADJUSTMENT*")
-    existing_unsent_orders = self.book.unsent_orders
-    self.book.unsent_orders = []
+    existing_ready_orders = self.book.ready_orders
+    self.book.ready_orders = []
     self.add_orders(side, count, first_size, first_price, size_change)
     self.send_orders()
-    self.book.unsent_orders = existing_unsent_orders
+    self.book.ready_orders = existing_ready_orders
 
   def cancel_orders_below_size(self, side, size):
     logger.info("*CANCELING ORDERS FOR ADJUSTMNET*")

--- a/trader/sequence/test/integration/test_book_manager.py
+++ b/trader/sequence/test/integration/test_book_manager.py
@@ -22,8 +22,9 @@ class TestBookManagerIntegration(unittest.TestCase):
       "BTC-USD", test=True
     )
     low_price = mid_price / 5
+    budget = mid_price * 3
     self.terms = TradingTerms(
-      "BTC-USD", "10000", ".01", ".015", low_price
+      "BTC-USD", budget, ".01", ".015", low_price
     )
     self.book_manager = BookManager(self.terms)
 
@@ -33,12 +34,12 @@ class TestBookManagerIntegration(unittest.TestCase):
     BaseWrapper.metadata.drop_all(Test_Engine)
 
   def test_init(self):
-    for order in self.book_manager.book.unsent_orders:
+    for order in self.book_manager.book.ready_orders:
       if logger.isEnabledFor(logging.DEBUG):
-        count = len(self.book_manager.book.unsent_orders)
+        count = len(self.book_manager.book.ready_orders)
         logger.debug(
-          "Verifying unsent order number {} of {}".format(
-            self.book_manager.book.unsent_orders.index(order) + 1,
+          "Verifying ready order number {} of {}".format(
+            self.book_manager.book.ready_orders.index(order) + 1,
             count
           )
         )
@@ -48,7 +49,7 @@ class TestBookManagerIntegration(unittest.TestCase):
       self.assertEqual(order_in_db[0], order.id)
       self.assertIsNone(order.exchange_id)
       self.assertIsNone(order_in_db[2])
-      self.assertEqual(order_in_db[8], "ready")
+      self.assertEqual(order_in_db[9], "ready")
 
   def test_send_order(self):
     self.book_manager.send_orders()
@@ -68,4 +69,4 @@ class TestBookManagerIntegration(unittest.TestCase):
       self.assertEqual(order_in_db[0], order.id)
       self.assertIsNotNone(order_in_db[2])
       self.assertEqual(order_in_db[2], order.exchange_id)
-      self.assertEqual(order_in_db[8], "open")
+      self.assertEqual(order_in_db[9], "open")

--- a/trader/test/test_trading_terms.py
+++ b/trader/test/test_trading_terms.py
@@ -163,7 +163,7 @@ class test_trading_terms(unittest.TestCase):
     self.terms.budget = 10000
     self.terms.size_change = .001
     self.terms.set_mid_price()
-    self.terms.low_price = self.terms.mid_price - 100
+    self.terms.low_price = self.terms.mid_price / 3
 
     buy_budget = round(self.terms.buy_budget, self.terms.price_decimals)
     sell_budget = self.terms.sell_budget
@@ -171,8 +171,8 @@ class test_trading_terms(unittest.TestCase):
       self.terms.quote_sell_budget, self.terms.price_decimals
     )
     mid = self.terms.mid_price
-    low = round(mid - 100, 2)
-    high = round(mid + 100, 2)
+    low = round(mid / 3, 2)
+    high = round(mid * Decimal(5 / 3), 2)
     count = self.terms.count
     price_change = self.terms.price_change
     skew = self.terms.skew


### PR DESCRIPTION
Book will now be persisted into the database and each order will be associated
with a book id. Cleaned up some tests that were failing when market was below
the tests threshold of viability.