### PR TITLE
Canceled orders repeatedly being canceled

### DIFF
--- a/trader/exchange/book.py
+++ b/trader/exchange/book.py
@@ -71,6 +71,13 @@ class Book(BaseWrapper):
       order = order_list.pop()
       trading.cancel_order(order)
       order.status = "canceled"
+      try:
+        self.open_orders.remove(order)
+      except ValueError:
+        logger.info("Order not found in open orders: {}".format(
+          order
+        ))
+
       self.canceled_orders.append(order)
       if self.persist:
         order.save()


### PR DESCRIPTION
a missing step to remove the canceled order from the open
order list was ommited causing repeated attempts to cancel orders
that had previously been canceled.