### PR TITLE
Adding adaptive perimeters for each product pair

### DIFF
--- a/trader/exchange/trading.py
+++ b/trader/exchange/trading.py
@@ -192,6 +192,20 @@ def get_products(test=True):
   return product_ids
 
 
+def get_product(pair, test=True):
+  """
+  Get product details.
+
+  returns dictionary with the following keys.
+  'id', 'base_currency', 'quote_currency', 'base_min_size', 'base_max_size',
+  'quote_increment', 'display_name', 'status', 'margin_enabled',
+  'status_message', 'min_market_funds', 'max_market_funds', 'post_only',
+  'limit_only', 'cancel_only'
+  """
+  url, auth = get_url_auth(test)
+  response = requests.get(url + "products/" + pair)
+  return response.json()
+
 def get_url_auth(test):
   if test:
     url = config.test_rest_api_url

--- a/trader/sequence/trading_terms.py
+++ b/trader/sequence/trading_terms.py
@@ -63,21 +63,15 @@ class TradingTerms():
 
     self._pair = value
     if value:
+      details = trading.get_product(value)
       # split pair into pertinent parts
-      self.base_pair = self.pair[:3]
-      self.quote_pair = self.pair[4:]
-
-      # Set Price rounding for USD pairs and non USD pairs
-      if self.quote_pair == 'USD':
-        self.price_decimals = "2"
-      else:
-        self.price_decimals = "5"
-
-      # Assign min_price if None
-      if self.base_pair == "LTC":
-        self.min_size = ".1"
-      else:
-        self.min_size = ".01"
+      self.base_pair = details["base_currency"]
+      self.quote_pair = details["quote_currency"]
+      # price_decimal is used to round, we want to exclude "0." from len
+      self.price_decimals = len(details["quote_increment"]) - 2
+      self.base_min_size = details["base_min_size"]
+      self.min_size = details["base_min_size"]
+      self.max_size = details["base_max_size"]
 
   # add definition of base_pair property here
   @property
@@ -137,16 +131,10 @@ class TradingTerms():
     if value:
       if self.base_pair is None:
         raise ValueError("Can't set minimum size without knowing pair")
-      elif self.base_pair == "LTC" and Decimal(value) < Decimal(".1"):
+      elif Decimal(value) < Decimal(self.base_min_size):
         raise ValueError(
-          "Minimum trade size for {} is .1".format(
-            self.pair
-          )
-        )
-      elif Decimal(value) < Decimal(".01"):
-        raise ValueError(
-          'Miminum size trade for {} is .01'.format(
-            self.pair
+          "Minimum trade size for {} is {}".format(
+            self.pair, self.base_min_size
           )
         )
       else:

--- a/trader/test/test_trading_terms.py
+++ b/trader/test/test_trading_terms.py
@@ -32,8 +32,13 @@ class test_trading_terms(unittest.TestCase):
     self.assertEqual(self.terms.pair, "BTC-USD")
     self.assertEqual(self.terms.base_pair, "BTC")
     self.assertEqual(self.terms.quote_pair, "USD")
-    self.assertEqual(self.terms.min_size, Decimal(".01"))
-    self.assertEqual(self.terms.price_decimals, 2)
+    self.assertEqual(type(self.terms.min_size), Decimal,
+                     msg="min_size is a Decimal")
+    self.assertGreater(self.terms.min_size, 0, msg="min_size is positive")
+    self.assertEqual(type(self.terms.price_decimals), int,
+                     msg="price_decimals is a n integer")
+    self.assertGreater(self.terms.price_decimals, 0,
+                       msg="price_decimal is positive")
 
     with self.assertRaises(ValueError):
       self.terms.pair = "ETH"
@@ -43,9 +48,6 @@ class test_trading_terms(unittest.TestCase):
     terms = TradingTerms("ETH-BTC", test=True)
 
     self.assertEqual(terms.pair, "ETH-BTC")
-    self.assertEqual(terms.min_size, Decimal("0.01"))
-    self.assertEqual(terms.price_decimals, 5)
-
     with self.assertRaises(ValueError):
       terms.quote_pair = "ETH"
     with self.assertRaises(ValueError):
@@ -170,6 +172,7 @@ class test_trading_terms(unittest.TestCase):
     quote_sell_budget = round(
       self.terms.quote_sell_budget, self.terms.price_decimals
     )
+    base_min_size = self.terms.base_min_size
     mid = self.terms.mid_price
     low = round(mid / 3, 2)
     high = round(mid * Decimal(5 / 3), 2)
@@ -189,7 +192,7 @@ class test_trading_terms(unittest.TestCase):
       buy_budget,
       sell_budget,
       quote_sell_budget,
-      "0.01", "0.00100000", low,
+      base_min_size, "0.00100000", low,
       mid, high, count,
       skew, price_change, test)
 


### PR DESCRIPTION
Coinbase Pro changed the minimum base currency minimum size for BTC-USD.
Most notably you can now make trades as small as .001 BTC per a given price
in USD. Instead of hard coding these sizes in for various products, a call
to the API is made to get the current parameters for trading within for the
given pair.