### PR TITLE
Modified the way trade adjustments are handled

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ coverage = "*"
 nose = "*"
 SQLAlchemy = ">=1.3.0"
 pymysql = "*"
+deprecated = "*"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -17,7 +17,6 @@ coverage = "*"
 nose = "*"
 SQLAlchemy = ">=1.3.0"
 pymysql = "*"
-deprecated = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f6ba5f094462051c6a604e3c69af173f87e788fb95ad713e1edb611bae616127"
+            "sha256": "ffae1ec42a2f901a7680042c4c80430853d6f98597386d623f8791e9e7cb183f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -71,6 +71,14 @@
             ],
             "index": "pypi",
             "version": "==4.5.3"
+        },
+        "deprecated": {
+            "hashes": [
+                "sha256:2f293eb0eee34b1fcf3da530fe8fc4b0d71d43ddc2dc78e2ffb444b6c0868557",
+                "sha256:749f6cdcfbdc3f79258f8154bad43fced95adc632c337675d0385959895894bc"
+            ],
+            "index": "pypi",
+            "version": "==1.2.5"
         },
         "idna": {
             "hashes": [
@@ -155,6 +163,15 @@
             ],
             "index": "pypi",
             "version": "==7.0"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:23695470a1aa70c69c46e255afcd10c573debdfe6f82733a0d71ee900fa15733",
+                "sha256:4a4851392ebd1b3a04de3707db3d469593366caa749da7aa21f62e1afb7bcabe",
+                "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533",
+                "sha256:abaafff0afc410c7d4ac28720dd7f627b52e842d109d592ef29cb209a43b273b"
+            ],
+            "version": "==1.11.1"
         }
     },
     "develop": {}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ffae1ec42a2f901a7680042c4c80430853d6f98597386d623f8791e9e7cb183f"
+            "sha256": "f6ba5f094462051c6a604e3c69af173f87e788fb95ad713e1edb611bae616127"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -72,14 +72,6 @@
             "index": "pypi",
             "version": "==4.5.3"
         },
-        "deprecated": {
-            "hashes": [
-                "sha256:2f293eb0eee34b1fcf3da530fe8fc4b0d71d43ddc2dc78e2ffb444b6c0868557",
-                "sha256:749f6cdcfbdc3f79258f8154bad43fced95adc632c337675d0385959895894bc"
-            ],
-            "index": "pypi",
-            "version": "==1.2.5"
-        },
         "idna": {
             "hashes": [
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
@@ -129,11 +121,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
-                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
+                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
+                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
             ],
             "index": "pypi",
-            "version": "==1.24.2"
+            "version": "==1.24.3"
         },
         "websockets": {
             "hashes": [
@@ -163,15 +155,6 @@
             ],
             "index": "pypi",
             "version": "==7.0"
-        },
-        "wrapt": {
-            "hashes": [
-                "sha256:23695470a1aa70c69c46e255afcd10c573debdfe6f82733a0d71ee900fa15733",
-                "sha256:4a4851392ebd1b3a04de3707db3d469593366caa749da7aa21f62e1afb7bcabe",
-                "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533",
-                "sha256:abaafff0afc410c7d4ac28720dd7f627b52e842d109d592ef29cb209a43b273b"
-            ],
-            "version": "==1.11.1"
         }
     },
     "develop": {}

--- a/trader/exchange/book.py
+++ b/trader/exchange/book.py
@@ -76,7 +76,7 @@ class Book(BaseWrapper):
       if order.post_only and order.reject_reason == "post only":
         self.rejected_orders.append(order)
         # Find first price available for post-only
-        logger.warn("Post-only rejected:\n{}".format(pformat(str(order))))
+        logger.warn("Post-only rejected:\n" + pformat(str(order)))
         # Recursive loop override rejected order, confirm happens in recursion
         return self.post_at_best_post_only(order.side, order.size)
       else:
@@ -88,9 +88,9 @@ class Book(BaseWrapper):
     elif order.status == "filled":
       self.filled_orders.append(order)
     else:
-      logger.error("Received {} status when sending order:\n{}".format(
-        order.status, pformat(order)
-      ))
+      logger.error("Received {} status when sending order:\n".format(
+        order.status) + pformat(order)
+      )
 
     if self.persist:
         order.save()
@@ -126,7 +126,7 @@ class Book(BaseWrapper):
       if self.persist:
         order.save()
 
-  def cancel_order(self, side, size):
+  def cancel_order_by_attribute(self, side, size):
     """
     Cancels order of matching side and size. When more than one, the oldest
     order will be canceled.

--- a/trader/exchange/test/unit/test_book.py
+++ b/trader/exchange/test/unit/test_book.py
@@ -146,6 +146,32 @@ class Test_Book(unittest.TestCase):
     self.assertEqual(self.book.rejected_orders[0].reject_reason, "post only")
     self.assertEqual(order_to_cancel.status, "canceled")
 
+  def test_cancel_order(self):
+    side = "buy"
+    size = ".1"
+    price1 = self.market_price / 2
+    price2 = self.market_price * 2 / 3
+    self.book.add_and_send_order(side, size, price1)
+    self.assertEqual(len(self.book.open_orders), 1,
+                     msg="One open order in book")
+    order1 = self.book.open_orders[0]
+    self.book.add_and_send_order(side, size, price2)
+    self.assertEqual(len(self.book.open_orders), 2,
+                     msg="Two open orders in book")
+    order2 = next(o for o in self.book.open_orders if o != order1)
+    self.book.cancel_order(side, Decimal(size))
+    self.assertEqual(len(self.book.open_orders), 1,
+                     msg="One open order in book")
+    self.assertEqual(len(self.book.canceled_orders), 1,
+                     msg="One open order in book")
+    open_order = self.book.open_orders[0]
+    canceled_order = self.book.canceled_orders[0]
+
+    self.assertEqual(open_order, order2,
+                     msg="Second posted order should not be canceled")
+    self.assertEqual(canceled_order, order1,
+                     msg="First posted order should be canceled")
+
   def get_ids(self):
     return [order["id"] for order in trading
             .get_open_orders(pair="BTC-USD", test=True)]

--- a/trader/exchange/test/unit/test_book.py
+++ b/trader/exchange/test/unit/test_book.py
@@ -146,7 +146,7 @@ class Test_Book(unittest.TestCase):
     self.assertEqual(self.book.rejected_orders[0].reject_reason, "post only")
     self.assertEqual(order_to_cancel.status, "canceled")
 
-  def test_cancel_order(self):
+  def test_cancel_order_by_attribute(self):
     side = "buy"
     size = ".1"
     price1 = self.market_price / 2
@@ -159,7 +159,7 @@ class Test_Book(unittest.TestCase):
     self.assertEqual(len(self.book.open_orders), 2,
                      msg="Two open orders in book")
     order2 = next(o for o in self.book.open_orders if o != order1)
-    self.book.cancel_order(side, Decimal(size))
+    self.book.cancel_order_by_attribute(side, Decimal(size))
     self.assertEqual(len(self.book.open_orders), 1,
                      msg="One open order in book")
     self.assertEqual(len(self.book.canceled_orders), 1,

--- a/trader/exchange/test/unit/test_book.py
+++ b/trader/exchange/test/unit/test_book.py
@@ -9,6 +9,7 @@ class Test_Book(unittest.TestCase):
   def setUp(self):
     self.book = Book("BTC-USD", persist=False, test=True)
     self.market_price = trading.get_mid_market_price("BTC-USD", test=True)
+    self.details = trading.get_product("BTC-USD", test=True)
 
   def test_book_init(self):
 
@@ -93,6 +94,48 @@ class Test_Book(unittest.TestCase):
     # move order back to open and cancel it.
     self.book.open_orders = [filled_order]
     self.book.cancel_all_orders()
+
+  def test_add_send_order(self):
+    side = "buy"
+    size = self.details['base_min_size']
+    price = self.market_price / Decimal("10")
+    self.book.add_and_send_order(
+      side, size, price)
+
+    self.assertEqual(len(self.book.open_orders), 1,
+                     msg="Order should be in open orders")
+    self.assertEqual(len(self.book.ready_orders), 0,
+                     msg="Nothing should be in ready_orders")
+    test_order = self.book.open_orders[0]
+
+    self.assertEqual(test_order.status, "open",
+                     msg="Status will be open")
+    trading.cancel_order(test_order)
+    self.assertEqual(test_order.status, "canceled",
+                     msg="failed to cancel order for test")
+
+  def test_add_send_order_no_post_only(self):
+    size = self.details['base_min_size']
+    side = "buy"
+    price = self.market_price * Decimal("5")
+    self.book.add_and_send_order(side, size, price, post_only=False)
+
+    self.assertEqual(len(self.book.filled_orders), 1)
+    self.assertEqual(len(self.book.open_orders), 0)
+    self.assertEqual(self.book.filled_orders[0].status, "filled")
+
+  def test_add_send_order_post_only(self):
+    size = self.details['base_min_size']
+    side = "buy"
+    price = self.market_price * Decimal("5")
+    self.book.add_and_send_order(side, size, price, post_only=True)
+
+    self.assertEqual(len(self.book.open_orders), 0,
+                     msg="Order should be rejected not open")
+    self.assertEqual(len(self.book.canceled_orders), 0,
+                     msg="Order should be rejected not canceled")
+    self.assertEqual(len(self.book.rejected_orders), 1,
+                     msg=("Post only order that would fill was not rejected"))
 
   def get_ids(self):
     return [order["id"] for order in trading

--- a/trader/exchange/trading.py
+++ b/trader/exchange/trading.py
@@ -28,18 +28,20 @@ def send_order(Order):
     "product_id": Order.pair,
     "post_only": Order.post_only
   }
-  logger.debug("sent order:\n" + pformat(json_order))
+  logger.debug("sent order:\n{}".format(pformat(json_order)))
   order_post = requests.post(
     url + 'orders',
     json=json_order,
     auth=auth
   )
   response = order_post.json()
-  logger.debug("response:\n" + pformat(response))
+  logger.debug("response:\n{}".format(pformat(response)))
   if "message" not in response:
     Order.responses.append(response)
     Order.exchange_id = response["id"]
     Order.status = response["status"]
+    if response["status"] == "rejected":
+      Order.reject_reason = response["reject_reason"]
     if Order.persist:
       Order.save()
 
@@ -133,9 +135,11 @@ def get_mid_market_price(pair, test=False):
 
 def get_first_book(pair, test=False):
   '''
-  book = {'asks': [['19000.01', '50000.07', 196]],
- 'bids': [['19000', '0.003', 3]],
- 'sequence': 45787580}
+  find first trades in book for given pair.
+
+  returns {'asks': [['19000.01', '50000.07', 196]],
+           'bids': [['19000', '0.003', 3]],
+           'sequence': 45787580}
   '''
   book = get_book(pair, 1, test=test)
   logger.debug(pformat(book))
@@ -209,6 +213,7 @@ def get_product(pair, test=True):
   url, auth = get_url_auth(test)
   response = requests.get(url + "products/" + pair)
   return response.json()
+
 
 def get_url_auth(test):
   if test:

--- a/trader/sequence/book_manager.py
+++ b/trader/sequence/book_manager.py
@@ -2,6 +2,8 @@ from decimal import Decimal
 import logging
 import logging.config
 
+from deprecated import deprecated
+
 from ..exchange.book import Book
 import config
 from ..database.manager import session, test_session
@@ -151,9 +153,10 @@ class BookManager():
     for i in range(count - 1):
       price = price + (plus_or_minus * self.price_change)
       size = size + self.size_change
-      self.book.cancel_order(side, price)
+      self.book.cancel_order(side, size, price)
       self.add_and_send_order(side, size, price)
 
+  @deprecated(reason="replaced with adjust_orders_for_matched_trade")
   def add_and_send_orders(self, side, count, first_size, first_price,
                           size_change):
     logger.info("*SENDING ORDERS FOR ADJUSTMENT*")
@@ -166,6 +169,7 @@ class BookManager():
   def add_and_send_order(self, side, size, price):
     self.book.add_and_send_order(side, size, price)
 
+  @deprecated(reason="replaced with adjust_orders_for_matched_trade")
   def cancel_orders_below_size(self, side, size):
     logger.info("*CANCELING ORDERS FOR ADJUSTMNET*")
     orders_to_cancel = [o for o in self.book.open_orders

--- a/trader/sequence/book_manager.py
+++ b/trader/sequence/book_manager.py
@@ -161,7 +161,7 @@ class BookManager():
     self.add_and_send_order(side, size, price)
     plus_or_minus = -1 if side == "buy" else 1
     for i in range(count - 1):
-      self.book.cancel_order(side, size)
+      self.book.cancel_order_by_attribute(side, size)
       price = price + (plus_or_minus * self.terms.price_change)
       size = size + self.terms.size_change
       self.add_and_send_order(side, size, price)

--- a/trader/sequence/book_manager.py
+++ b/trader/sequence/book_manager.py
@@ -107,26 +107,29 @@ class BookManager():
       )
 
       if self.full_match(match, order):
-
-        # Mark order as filled
-        self.book.order_filled(order)
-
-        side, plus_minus = ("buy", -1) if order.side == "sell" else ("sell", 1)
-        count = int(1 +
-                    (order.size - self.terms.min_size) /
-                    self.terms.size_change)
-        first_price = order.price + plus_minus * self.terms.price_change
-        self.adjust_orders_for_matched_trade(
-          side, self.min_size, count, first_price)
-
+        self.when_full_match(order)
       else:
-        matched = Decimal(match["size"])
-        logger.info("Partially filled, {} filled {}."
-                    .format(matched, order.size - order.filled))
-        order.filled += matched
-        if self.persist:
-          order.save()
-          order.session.commit()
+        self.when_partial_match(Decimal(match["size"]), order)
+
+  def when_full_match(self, order):
+    # Mark order as filled
+    self.book.order_filled(order)
+
+    side, plus_minus = ("buy", -1) if order.side == "sell" else ("sell", 1)
+    count = int(1 +
+                (order.size - self.terms.min_size) /
+                self.terms.size_change)
+    first_price = order.price + plus_minus * self.terms.price_change
+    self.adjust_orders_for_matched_trade(
+      side, count, first_price)
+
+  def when_partial_match(self, filled_size, order):
+    logger.info("Partially filled, {} was filled, {} remaining."
+                .format(filled_size, order.size - order.filled))
+    order.filled += filled_size
+    if self.persist:
+      order.save()
+      order.session.commit()
 
   def matched_book_order(self, match):
     if logger.isEnabledFor(logging.DEBUG):
@@ -145,38 +148,23 @@ class BookManager():
     return Decimal(match['size']) == order.size - order.filled
 
   def adjust_orders_for_matched_trade(
-    self, side, size, count, price):
+    self, side, count, price):
+    """
+    When an open order is matched, the matched value is distributed across the
+    opposite side trades by adjusting all of those smaller then the matched
+    trade by the size change. To do this, each trade must be canceled and
+    reposted at the adjusted amount.
+    """
     logger.info("*ADJUSTING ORDERS FOR MATCHED TRADE*")
     # list first trade right away
+    size = self.terms.min_size
     self.add_and_send_order(side, size, price)
     plus_or_minus = -1 if side == "buy" else 1
     for i in range(count - 1):
-      price = price + (plus_or_minus * self.price_change)
-      size = size + self.size_change
-      self.book.cancel_order(side, size, price)
+      self.book.cancel_order(side, size)
+      price = price + (plus_or_minus * self.terms.price_change)
+      size = size + self.terms.size_change
       self.add_and_send_order(side, size, price)
-
-  @deprecated(reason="replaced with adjust_orders_for_matched_trade")
-  def add_and_send_orders(self, side, count, first_size, first_price,
-                          size_change):
-    logger.info("*SENDING ORDERS FOR ADJUSTMENT*")
-    existing_ready_orders = self.book.ready_orders
-    self.book.ready_orders = []
-    self.add_orders(side, count, first_size, first_price, size_change)
-    self.send_orders()
-    self.book.ready_orders = existing_ready_orders
 
   def add_and_send_order(self, side, size, price):
     self.book.add_and_send_order(side, size, price)
-
-  @deprecated(reason="replaced with adjust_orders_for_matched_trade")
-  def cancel_orders_below_size(self, side, size):
-    logger.info("*CANCELING ORDERS FOR ADJUSTMNET*")
-    orders_to_cancel = [o for o in self.book.open_orders
-                        if o.side == side and o.size <= size]
-    self.book.cancel_order_list(orders_to_cancel)
-    if self.persist:
-      if self.test:
-        test_session.commit()
-      else:
-        session.commit()

--- a/trader/sequence/trading_terms.py
+++ b/trader/sequence/trading_terms.py
@@ -67,9 +67,10 @@ class TradingTerms():
       # split pair into pertinent parts
       self.base_pair = details["base_currency"]
       self.quote_pair = details["quote_currency"]
-      # price_decimal is used to round, we want to exclude "0." from len
+      # price_decimal is used to round, we want to exclude "0." from length
       self.price_decimals = len(details["quote_increment"]) - 2
       self.base_min_size = details["base_min_size"]
+      self.quote_increment = details["quote_increment"]
       self.min_size = details["base_min_size"]
       self.max_size = details["base_max_size"]
 

--- a/trader/sequence/trading_terms.py
+++ b/trader/sequence/trading_terms.py
@@ -195,8 +195,7 @@ class TradingTerms():
 
   def set_mid_price(self):
     if self.pair:
-      self._mid_price = Decimal(trading.get_mid_market_price(self.pair,
-                                                             test=self.test))
+      self._mid_price = trading_mid_market_price(self.pair, self.test)
       logger.info("{} currently trading at {}"
                   .format(self.pair, self.mid_price))
     else:
@@ -353,6 +352,10 @@ class TradingTerms():
         self.mid_price, self.high_price, self.count,
         self.skew, self.price_change, self.test)
     return output
+
+
+def trading_mid_market_price(pair, test=True):
+  return Decimal(trading.get_mid_market_price(pair, test=test))
 
 
 def find_count(S0, SD, PL, PM, PH, BU):

--- a/trader/test/test_book_manager.py
+++ b/trader/test/test_book_manager.py
@@ -1,21 +1,52 @@
-import unittest
 from decimal import Decimal
+import logging
+import logging.config
+import unittest
+from unittest.mock import Mock
+import uuid
 
+import config
 from ..sequence.book_manager import BookManager
-from ..sequence.trading_terms import TradingTerms
-from ..exchange import trading
+from ..sequence import trading_terms
+
+
+logging.config.dictConfig(config.log_config)
+logger = logging.getLogger(__name__)
 
 
 class TestBookManager(unittest.TestCase):
 
   def setUp(self):
-    self.mid_price = trading.get_mid_market_price("BTC-USD", test=True)
-    low_price = self.mid_price / 5
-    budget = self.mid_price * 4
-    self.terms = TradingTerms(
-      "BTC-USD", budget, ".01", ".15", low_price, test=True
+    """
+    Test case set up
+    | price | size | value |
+    |   900 |  1.7 |   850 |
+    |   800 |  1.5 |   750 |
+    |   700 |  1.3 |   650 |
+    |   600 |  1.1 |   550 |
+    |   500 |      |       |
+    |   400 |  1.0 |   400 |
+    |   300 |  1.2 |   360 |
+    |   200 |  1.4 |   280 |
+    |   100 |  1.6 |   160 |
+             total |  4000 |
+             fee   |    12 |
+    """
+    trading_terms.trading_mid_market_price = Mock(side_effect=[Decimal("500")])
+    self.mid_price = Decimal("500")
+    low_price = "100"
+    budget = Decimal("4000") * (1 + Decimal(config.CB_FEE))
+    self.terms = trading_terms.TradingTerms(
+      "BTC-USD", budget, "1", ".1", low_price, test=True
     )
     self.BookManager = BookManager(self.terms, persist=False)
+    self.BookManager.book.send_order = Mock(
+      side_effect=self.book_send_order_mock)
+    self.BookManager.book.trading_cancel_order = Mock()
+
+  # def tearDown(self):
+  #   self.BookManager.book.cancel_all_orders()
+  #   self.assertEqual(self.BookManager.book.open_orders, [])
 
   def test_BookManager_init(self):
     self.assertEqual(self.terms, self.BookManager.terms)
@@ -32,60 +63,190 @@ class TestBookManager(unittest.TestCase):
                  if order.side == "sell"]
     sell_budget = sum(sell_list) * self.terms.mid_price
     sell_budget = round(sell_budget, 2)
-    budget = sell_budget + buy_budget
-    upper_bound = self.terms.budget
-    last_buy = int(self.terms.count / 2 - 1)
-    last_sell = int(self.terms.count - 1)
-    rounded_off_buy_trade = ((book.ready_orders[last_buy].size -
-                              self.terms.size_change) *
-                             (book.ready_orders[last_buy].price +
-                              self.terms.price_change))
-    rounded_off_sell_trade = (book.ready_orders[last_sell].size +
-                              self.terms.size_change) * self.terms.mid_price
-    lower_bound = (self.mid_price - rounded_off_buy_trade -
-                   rounded_off_sell_trade
-                   )
-    # price distribution.
-    self.assertLessEqual(budget, upper_bound)
-    self.assertGreaterEqual(budget, lower_bound)
+    budget_without_fee = sell_budget + buy_budget
+
+    self.assertEqual(budget_without_fee, self.terms.budget /
+                     (1 + Decimal(config.CB_FEE)))
+    self.assertEqual(len(self.BookManager.book.ready_orders), 8)
+    actual_order = [(o.side, str(o.price), str(o.size)) for o in
+                    self.BookManager.book.ready_orders]
+    expected_order = [("buy", "400.00", "1.00000000"),
+                      ("buy", "300.00", "1.20000000"),
+                      ("buy", "200.00", "1.40000000"),
+                      ("buy", "100.00", "1.60000000"),
+                      ("sell", "600.00", "1.10000000"),
+                      ("sell", "700.00", "1.30000000"),
+                      ("sell", "800.00", "1.50000000"),
+                      ("sell", "900.00", "1.70000000"),
+                      ]
+    self.assertEqual(expected_order, actual_order)
 
   def test_BookManager_send_orders(self):
     self.BookManager.send_orders()
     self.assertEqual(self.BookManager.book.ready_orders, [])
-    sent_order_ids = {
-      order.exchange_id for order
-      in self.BookManager.book.open_orders
-    }
+    actual_order = [(o.side, str(o.price), str(o.size)) for o in
+                    self.BookManager.book.open_orders]
+    expected_order = [("sell", "600.00", "1.10000000"),
+                      ("buy", "400.00", "1.00000000"),
+                      ("sell", "700.00", "1.30000000"),
+                      ("buy", "300.00", "1.20000000"),
+                      ("sell", "800.00", "1.50000000"),
+                      ("buy", "200.00", "1.40000000"),
+                      ("sell", "900.00", "1.70000000"),
+                      ("buy", "100.00", "1.60000000"),
+                      ]
+    self.assertEqual(actual_order, expected_order)
+    for order in self.BookManager.book.open_orders:
+      self.BookManager.book.send_order.assert_any_call(order)
 
-    # Check exchange for orders
-    for order_id in sent_order_ids:
-      response = trading.order_status(order_id)
-      self.assertEqual(order_id, response["id"])
-
-    canceled_order_ids = {trading.cancel_order_by_id(id, test=True)[0]
-                          for id in sent_order_ids}
-    self.assertEqual(sent_order_ids, canceled_order_ids)
-
-  def test_BookManager_add_and_send_order(self):
+  def test_BookManager_adjust_orders_for_matched_trade_matched_buy(self):
     self.BookManager.send_orders()
-    first_size = self.terms.min_size
-    first_price = round(self.terms.mid_price -
-                        self.terms.price_change * Decimal(".75"))
-    count = int(self.terms.trade_count / 4)
-    self.BookManager.add_and_send_orders("buy",
-                                         count, first_size,
-                                         first_price,
-                                         self.terms.size_change)
 
-    sent_order_ids = {
-      order.exchange_id for order in self.BookManager.book.open_orders
-    }
+    buy_order = next(o for o in self.BookManager.book.open_orders if o.size ==
+                     Decimal("1"))
+    self.BookManager.book.order_filled(buy_order)
+    self.BookManager.adjust_orders_for_matched_trade(
+      "sell", 1, Decimal("500")
+    )
+    actual_order = [(o.side, str(o.price), str(o.size)) for o in
+                    self.BookManager.book.open_orders]
+    expected_order = [('sell', '600.00', '1.10000000'),
+                      ("sell", "700.00", "1.30000000"),
+                      ("buy", "300.00", "1.20000000"),
+                      ("sell", "800.00", "1.50000000"),
+                      ("buy", "200.00", "1.40000000"),
+                      ("sell", "900.00", "1.70000000"),
+                      ("buy", "100.00", "1.60000000"),
+                      ("sell", "500.00", "1")
+                      ]
+    self.assertEqual(actual_order, expected_order)
+    self.assertEqual(self.BookManager.book.filled_orders, [buy_order])
+    self.BookManager.book.send_order.assert_any_call(buy_order)
+    for order in self.BookManager.book.open_orders:
+      self.BookManager.book.send_order.assert_any_call(order)
 
-    # Check exchange for orders
-    for order_id in sent_order_ids:
-      response = trading.order_status(order_id)
-      self.assertEqual(order_id, response["id"])
+  def test_BookManager_adjust_orders_for_matched_trade_matched_sell(self):
+    self.BookManager.send_orders()
+    sell_order = next(o for o in self.BookManager.book.open_orders if o.size ==
+                      Decimal("1.1"))
+    canceled_order = next(o for o in self.BookManager.book.open_orders if
+                          o.size == Decimal("1"))
+    self.BookManager.book.order_filled(sell_order)
+    self.BookManager.adjust_orders_for_matched_trade(
+      "buy", 2, Decimal("500")
+    )
+    actual_order = [(o.side, str(o.price), str(o.size)) for o in
+                    self.BookManager.book.open_orders]
+    expected_order = [("sell", "700.00", "1.30000000"),
+                      ("buy", "300.00", "1.20000000"),
+                      ("sell", "800.00", "1.50000000"),
+                      ("buy", "200.00", "1.40000000"),
+                      ("sell", "900.00", "1.70000000"),
+                      ("buy", "100.00", "1.60000000"),
+                      ("buy", "500.00", "1"),
+                      ("buy", "400.00", "1.10000000")
+                      ]
+    self.assertEqual(actual_order, expected_order)
+    self.assertEqual(self.BookManager.book.canceled_orders, [canceled_order])
+    self.assertEqual(self.BookManager.book.filled_orders, [sell_order])
+    self.BookManager.book.trading_cancel_order.assert_any_call(canceled_order)
+    self.BookManager.book.send_order.assert_any_call(canceled_order)
+    self.BookManager.book.send_order.assert_any_call(sell_order)
+    for order in self.BookManager.book.open_orders:
+      self.BookManager.book.send_order.assert_any_call(order)
 
-    canceled_order_ids = {trading.cancel_order_by_id(id, test=True)[0]
-                          for id in sent_order_ids}
-    self.assertEqual(sent_order_ids, canceled_order_ids)
+  def test_BookManager_when_full_match_three_buys(self):
+    self.BookManager.send_orders()
+    first_order = next(o for o in self.BookManager.book.open_orders if
+                       o.size == Decimal("1"))
+    second_order = next(o for o in self.BookManager.book.open_orders if
+                        o.size == Decimal("1.2"))
+    third_order = next(o for o in self.BookManager.book.open_orders if
+                       o.size == Decimal("1.4"))
+    first_open = self.BookManager.book.open_orders.copy()
+    self.BookManager.when_full_match(first_order)
+    second_open = [o for o in self.BookManager.book.open_orders if o not in
+                   first_open]
+    self.BookManager.when_full_match(second_order)
+    third_open = [o for o in self.BookManager.book.open_orders if o not in
+                  first_open and o not in second_open]
+    self.BookManager.when_full_match(third_order)
+    forth_open = [o for o in self.BookManager.book.open_orders if o not in
+                  first_open and o not in second_open and o not in third_open]
+    actual_order = [(o.side, str(o.price), str(o.size)) for o in
+                    self.BookManager.book.open_orders]
+    expected_order = [("sell", "800.00", "1.50000000"),
+                      ("sell", "900.00", "1.70000000"),
+                      ("buy", "100.00", "1.60000000"),
+                      ("sell", "300.00", "1"),
+                      ('sell', '400.00', '1.10000000'),
+                      ("sell", "500.00", "1.20000000"),
+                      ("sell", "600.00", "1.30000000"),
+                      ('sell', '700.00', '1.40000000'),
+                      ]
+    self.assertEqual(actual_order, expected_order)
+    self.assertEqual(self.BookManager.book.filled_orders, [
+      first_order, second_order, third_order
+    ])
+    for order in first_open:
+      self.BookManager.book.send_order.assert_any_call(order)
+    for order in second_open:
+      self.BookManager.book.send_order.assert_any_call(order)
+    for order in third_open:
+      self.BookManager.book.send_order.assert_any_call(order)
+    for order in forth_open:
+      self.BookManager.book.send_order.assert_any_call(order)
+    for order in self.BookManager.book.canceled_orders:
+      self.BookManager.book.trading_cancel_order.assert_any_call(order)
+
+  def test_BookManager_when_full_match_three_sells(self):
+    self.BookManager.send_orders()
+    first_order = next(o for o in self.BookManager.book.open_orders if
+                       o.size == Decimal("1.1"))
+    second_order = next(o for o in self.BookManager.book.open_orders if
+                        o.size == Decimal("1.3"))
+    third_order = next(o for o in self.BookManager.book.open_orders if
+                       o.size == Decimal("1.5"))
+    first_open = self.BookManager.book.open_orders.copy()
+    self.BookManager.when_full_match(first_order)
+    second_open = [o for o in self.BookManager.book.open_orders if o not in
+                   first_open]
+    self.BookManager.when_full_match(second_order)
+    third_open = [o for o in self.BookManager.book.open_orders if o not in
+                  first_open and o not in second_open]
+    self.BookManager.when_full_match(third_order)
+    forth_open = [o for o in self.BookManager.book.open_orders if o not in
+                  first_open and o not in second_open and o not in third_open]
+    actual_order = [(o.side, str(o.price), str(o.size)) for o in
+                    self.BookManager.book.open_orders]
+    expected_order = [("sell", "900.00", "1.70000000"),
+                      ("buy", "100.00", "1.60000000"),
+                      ("buy", "700.00", "1"),
+                      ("buy", "600.00", "1.10000000"),
+                      ("buy", "500.00", "1.20000000"),
+                      ("buy", "400.00", "1.30000000"),
+                      ("buy", "300.00", "1.40000000"),
+                      ("buy", "200.00", "1.50000000"),
+                      ]
+    self.assertEqual(actual_order, expected_order)
+    self.assertEqual(self.BookManager.book.filled_orders, [
+      first_order, second_order, third_order
+    ])
+    for order in first_open:
+      self.BookManager.book.send_order.assert_any_call(order)
+    for order in second_open:
+      self.BookManager.book.send_order.assert_any_call(order)
+    for order in third_open:
+      self.BookManager.book.send_order.assert_any_call(order)
+    for order in forth_open:
+      self.BookManager.book.send_order.assert_any_call(order)
+    for order in self.BookManager.book.canceled_orders:
+      self.BookManager.book.trading_cancel_order.assert_any_call(order)
+
+  def book_send_order_mock(self, order):
+    logger.debug("MOCK SEND ORDER")
+    logger.debug(type(self))
+    order.status = "open"
+    order.exchange_id = str(uuid.uuid4())
+    self.BookManager.book.open_orders.append(order)
+    return order


### PR DESCRIPTION
When an order in the trading strategy is filled, adjustments were
made in two steps, cancel trades that needed adjustment and post
new adjusted trades. Now the first trade, which is never an adjustmnet,
will be posted, and all trades following will be canceled and adjusted
one at a time. This should aliviate error logging when later canceling
trades that never posted due to being post-only and market conditions
changing while canceling all of the trades that need adjusting. Step
towards #48